### PR TITLE
Install /usr/lib/qt5/bin/servicefw only from one package.

### DIFF
--- a/rpm/qtsystems.spec
+++ b/rpm/qtsystems.spec
@@ -193,7 +193,6 @@ find %{buildroot}%{_libdir} -type f -name '*.prl' \
 %defattr(-,root,root,-)
 %{_libdir}/libQt5SystemInfo.so.5
 %{_libdir}/libQt5SystemInfo.so.5.*
-%{_qt5_bindir}/*
 
 %files -n qt5-qtsysteminfo-devel
 %defattr(-,root,root,-)
@@ -212,6 +211,7 @@ find %{buildroot}%{_libdir} -type f -name '*.prl' \
 %files -n qt5-qtserviceframework
 %defattr(-,root,root,-)
 %{_qt5_bindir}/servicefw
+%{_qt5_bindir}/sfwlisten
 %{_libdir}/libQt5ServiceFramework.so.5
 %{_libdir}/libQt5ServiceFramework.so.5.*
 


### PR DESCRIPTION
Currently /usr/lib/qt5/bin/servicefw binary is installed from two different packages: qt5-qtserviceframework and qt5-qtsysteminfo. Each file should be installed only from one package and this will fix and install the file only from qt5-qtserviceframework package.
