### PR TITLE
Fix memory leak in QBatteryInfoPrivate

### DIFF
--- a/src/systeminfo/linux/qbatteryinfo_statefs.cpp
+++ b/src/systeminfo/linux/qbatteryinfo_statefs.cpp
@@ -82,6 +82,12 @@ QBatteryInfoPrivate::QBatteryInfoPrivate(int, QBatteryInfo *parent)
     init();
 }
 
+QBatteryInfoPrivate::~QBatteryInfoPrivate()
+{
+    for (auto p : properties_)
+        delete p;
+}
+
 #define PROP_CONNECTED(parent, name)                \
     std::make_pair(QString(QS_("Battery." #name)),  \
                    &QBatteryInfoPrivate::on##name)

--- a/src/systeminfo/linux/qbatteryinfo_statefs_p.h
+++ b/src/systeminfo/linux/qbatteryinfo_statefs_p.h
@@ -70,7 +70,7 @@ class QBatteryInfoPrivate : public QObject
 public:
     QBatteryInfoPrivate(QBatteryInfo *);
     QBatteryInfoPrivate(int, QBatteryInfo *);
-    ~QBatteryInfoPrivate() {}
+    ~QBatteryInfoPrivate();
 
     bool isValid() const;
     int level() const;


### PR DESCRIPTION
 ==2269== 29,170 (600 direct, 28,570 indirect) bytes in 50 blocks are definitely lost in loss record 1,090 of 1,090
 ==2269==    at 0x482DE45: operator new(unsigned int) (vg_replace_malloc.c:292)
 ==2269==    by 0x49F9067: QBatteryInfoPrivate::init() (qbatteryinfo_statefs.cpp:135)
 ==2269==    by 0x49D6B1A: QBatteryInfo::QBatteryInfo(QObject_) (qbatteryinfo.cpp:153)
 ==2269==    by 0x123847: Buteo::Synchronizer::startSync(QString const&, bool) (synchronizer.cpp:437)
 ==2269==    by 0x124454: Buteo::Synchronizer::slotNetworkSessionOpened() (synchronizer.cpp:320)
 ==2269==    by 0x1852CA: Buteo::Synchronizer::qt_static_metacall(QObject_, QMetaObject::Call, int, void*_) (moc_synchronizer.cpp:307)
 ==2269==    by 0x4ED30F2: QMetaCallEvent::placeMetaCall(QObject_) (qobject.cpp:487)
 ==2269==    by 0x4ED73F6: QObject::event(QEvent_) (qobject.cpp:1147)
 ==2269==    by 0x4EA62D4: QCoreApplicationPrivate::notify_helper(QObject_, QEvent_) (qcoreapplication.cpp:1003)
 ==2269==    by 0x4EA635A: QCoreApplication::notify(QObject_, QEvent_) (qcoreapplication.cpp:948)
 ==2269==    by 0x4EA6044: QCoreApplication::notifyInternal(QObject_, QEvent_) (qcoreapplication.cpp:886)
 ==2269==    by 0x4EA90B6: QCoreApplicationPrivate::sendPostedEvents(QObject_, int, QThreadData_) (qcoreapplication.h:232)
 ==2269==    by 0x4EA9723: QCoreApplication::sendPostedEvents(QObject_, int) (qcoreapplication.cpp:1348)
 ==2269==    by 0x4F01D08: postEventSourceDispatch(_GSource_, int (_)(void_), void_) (qeventdispatcher_glib.cpp:284)
 ==2269==    by 0x5680527: g_main_context_dispatch (gmain.c:3066)
 ==2269==    by 0x5680897: g_main_context_iterate.isra.5 (gmain.c:3713)
 ==2269==    by 0x568095A: g_main_context_iteration (gmain.c:3774)
 ==2269==    by 0x4F01447: QEventDispatcherGlib::processEvents(QFlagsQEventLoop::ProcessEventsFlag) (qeventdispatcher_glib.cpp:438)
 ==2269==    by 0x4EA3E08: QEventLoop::processEvents(QFlagsQEventLoop::ProcessEventsFlag) (qeventloop.cpp:136)
 ==2269==    by 0x4EA428E: QEventLoop::exec(QFlagsQEventLoop::ProcessEventsFlag) (qeventloop.cpp:212)
 ==2269==    by 0x4EAC043: QCoreApplication::exec() (qcoreapplication.cpp:1139)
 ==2269==    by 0x110B04: main (main.cpp:69)
