### PR TITLE
[battery] assign parent to ContextProperties

### DIFF
--- a/src/systeminfo/linux/qbatteryinfo_statefs.cpp
+++ b/src/systeminfo/linux/qbatteryinfo_statefs.cpp
@@ -132,7 +132,7 @@ void QBatteryInfoPrivate::init()
         auto const &name = info.first;
         auto target = info.second;
 
-        auto property = new ContextProperty(name);
+        auto property = new ContextProperty(name, this);
         properties_.push_back(property);
         if (target)
             connect(property, &ContextProperty::valueChanged, this, target);


### PR DESCRIPTION
Otherwise there is a memory leak. Bug found by monich@github.

Signed-off-by: Denis Zalevskiy denis.zalevskiy@jolla.com
